### PR TITLE
Fix headshot % crash

### DIFF
--- a/src/player_stats.py
+++ b/src/player_stats.py
@@ -28,7 +28,8 @@ class PlayerStats:
                             total_headshots += hits["headshots"]
 
             # print(f"Total hits: {total_hits}\nTotal headshots: {total_headshots}\nHS%: {round((total_headshots/total_hits)*100, 1)}")
-
+            if total_hits == 0: # No hits
+                return "N/a"
             hs = int((total_headshots/total_hits)*100)
             return hs
         except IndexError: #no matches


### PR DESCRIPTION
When total_hits is 0, this results in DivisionByZero Exception since we are dividing by 0 here to calculate head shot %. This PR adds a check for that and handles it.


```
[2022.08.08-13.35.40] Traceback (most recent call last):
File "\src\player_stats.py"

    hs = int((total_headshots/total_hits)*100)
ZeroDivisionError: division by zero
```