### PR TITLE
Changed README.md to include Visual C++ dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@
 
 ### Bundled Release:
 
-1) Download the [release](https://github.com/isaacKenyon/valorant-rank-yoinker/releases/latest).
-2) Extract **all** files.
-3) Run vRY.exe.
+1) Download [Microsoft Visual C++ Libraries](https://github.com/abbodi1406/vcredist/releases)
+2) Download the [release](https://github.com/isaacKenyon/valorant-rank-yoinker/releases/latest).
+3) Extract **all** files.
+4) Run vRY.exe.
 
 ### Running from source:
 


### PR DESCRIPTION
Microsoft Visual C++ 2015 seems to be a vRY dependency, because of this issue: https://discord.com/channels/872101595037446144/1078240840700395531/1078240840700395531

vcruntime140.dll is part of Visual C++ 2015 - people who don't have it will not be able to run the bundled release.

This change includes Visual C++ to be a dependency, as well as a link to install it.