### PR TITLE
OS logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,8 @@ from src.chatlogs import ChatLogging
 
 from src.rpc import Rpc
 
+from src.os import get_os
+
 from colr import color as colr
 
 from rich.console import Console as RichConsole
@@ -56,6 +58,14 @@ def program_exit(status: int):  # so we don't need to import the entire sys modu
 try:
     Logging = Logging()
     log = Logging.log
+
+    # OS Logging + quit if OS unsupported
+    if get_os()[1] == False:
+        print(f"Unsupported operating system: {get_os()[0]}\n")
+        log(f"Unsupported operating system: {get_os()[0]}\n")
+        program_exit(0)
+    else:
+        log(f"Operating system: {get_os()[0]}\n")
 
     ChatLogging = ChatLogging()
     chatlog = ChatLogging.chatLog

--- a/src/os.py
+++ b/src/os.py
@@ -1,0 +1,23 @@
+import platform
+
+# This function detects the OS the user is running and if Valorant is officially supported in said platform
+# returns ["operating system" (string), "Runs Valorant" (bool)]
+def get_os():   
+    system = platform.system()
+    
+    if system == "Windows":
+        # Detects if Windows version **is not** 10 or 11
+        if platform.win32_ver()[0] != str(10 or 11):
+            return f"Windows {platform.win32_ver()[0]} {platform.win32_edition()} {platform.win32_ver()[1]}", False
+        
+        # Workaround for Windows 11 being detected as Windows 10, might not be necessary in the future
+        # https://github.com/python/cpython/issues/89545
+        if int(platform.win32_ver()[1].split(".")[-1]) >= 22000:
+            return f"Windows 11 {platform.win32_edition()} {platform.win32_ver()[1]}", True
+        else:
+            return f"Windows 10 {platform.win32_edition()} {platform.win32_ver()[1]}", True
+        
+
+    # Handles other Operating systems, such as Linux or Mac OS
+    else:
+        return "Non-Windows operating system", False


### PR DESCRIPTION
I implemented code that will detect the OS the user is running, and will register to the log file. This might help when providing support to people with issues.

If a user tries to run vRY in a unsupported platform (Windows 8.1 or below, Mac OS or Linux), it'll also be logged and printed "Unsupported operating system"

I tested the code on a variety of operating systems to make sure people wouldn't be impacted by the changes and that the OS logging would work correctly. Here are some testings I made:

Windows 11
![Windows 11](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/112394805/d98e9eeb-a6ac-431d-9d73-30810477ab06)

Windows 10
![Windows 10](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/112394805/9aa64ef0-a069-43e4-858e-10102978d338)

Windows 8.1
![Windows 8 1](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/112394805/fd08ae49-6c50-4f0e-aa86-6584809d07e0)

Fedora Linux 38 (result should be the same for all linux OS btw)
![Linux](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/112394805/05346807-7f15-43ca-90fc-4f2dc040a02e)
