### PR TITLE
Added rank & RR aggregation feature and its new config flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -374,6 +374,8 @@ try:
 
                         # RANK
                         rankName = NUMBERTORANKS[playerRank["rank"]]
+                        if cfg.get_feature_flag("aggregate_rank_rr") and cfg.table.get("rr"):
+                            rankName += f" ({playerRank['rr']})"
 
                         # RANK RATING
                         rr = playerRank["rr"]
@@ -527,6 +529,8 @@ try:
 
                         # RANK
                         rankName = NUMBERTORANKS[playerRank["rank"]]
+                        if cfg.get_feature_flag("aggregate_rank_rr") and cfg.table.get("rr"):
+                            rankName += f" ({playerRank['rr']})"
 
                         # RANK RATING
                         rr = playerRank["rr"]
@@ -611,6 +615,8 @@ try:
 
                             # RANK
                             rankName = NUMBERTORANKS[playerRank["rank"]]
+                            if cfg.get_feature_flag("aggregate_rank_rr") and cfg.table.get("rr"):
+                                rankName += f" ({playerRank['rr']})"
 
                             # RANK RATING
                             rr = playerRank["rr"]
@@ -670,6 +676,9 @@ try:
                     if isRange:
                         table.set_runtime_col_flag('Party', False)
                         table.set_runtime_col_flag('Agent',False)
+
+                # We don't to show the RR column if the "aggregate_rank_rr" feature flag is True.
+                table.set_runtime_col_flag('RR', cfg.table.get("rr") and not cfg.get_feature_flag("aggregate_rank_rr"))
 
                 table.set_caption(f"VALORANT rank yoinker v{version}")
                 table.display()

--- a/src/constants.py
+++ b/src/constants.py
@@ -169,6 +169,7 @@ DEFAULT_CONFIG = {
             "pre_cls": False,
             "game_chat": True,
             "peak_rank_act": True,
-            "discord_rpc": True
+            "discord_rpc": True,
+            "aggregate_rank_rr" : False
         }
     }

--- a/src/constants.py
+++ b/src/constants.py
@@ -170,6 +170,6 @@ DEFAULT_CONFIG = {
             "game_chat": True,
             "peak_rank_act": True,
             "discord_rpc": True,
-            "aggregate_rank_rr" : False
+            "aggregate_rank_rr": True
         }
     }

--- a/src/questions.py
+++ b/src/questions.py
@@ -17,7 +17,8 @@ FLAGS_OPTS = {
     "pre_cls": "Pre-Clear Screen",
     "game_chat": "Print Game Chat",
     "peak_rank_act": "Peak Rank Act",
-    "discord_rpc": "Discord Rich Presence"
+    "discord_rpc": "Discord Rich Presence",
+    "aggregate_rank_rr": "Display Rank and Ranked Rating in the same column"
 }
 
 weapon_question = lambda config: {


### PR DESCRIPTION
Added a feature to aggregate the rank and RR in the same column, with its new associated config flag `aggregate_rank_rr`.
The aggregation is effective only if the aforementioned flag is `true` and the table flag `rr` is also `true`.

Let me know if you want anything changed on the PR, I might have missed things somewhere :)

