### PR TITLE
Now encoding string to UTF-8 when checking length in print_message

### DIFF
--- a/src/websocket.py
+++ b/src/websocket.py
@@ -123,8 +123,8 @@ class Ws:
         if self.messages > self.chat_limit:
             print(self.up * self.chat_limit, end="")
             for i in range(len(self.message_history) - self.chat_limit + 1, len(self.message_history)):
-                print(self.message_history[i] + " " * max([0, len(self.colors.escape_ansi(self.message_history[i-1])) - len(self.colors.escape_ansi(self.message_history[i]))]))
-            print(message + " " * max([0, len(self.colors.escape_ansi(self.message_history[-1])) - len(self.colors.escape_ansi(message))]))
+                print(self.message_history[i] + " " * max([0, len(self.colors.escape_ansi(self.message_history[i-1]).encode('utf8')) - len(self.colors.escape_ansi(self.message_history[i]).encode('utf8'))]))
+            print(message + " " * max([0, len(self.colors.escape_ansi(self.message_history[-1]).encode('utf8')) - len(self.colors.escape_ansi(message).encode('utf8'))]))
         else:
             print(message)
 


### PR DESCRIPTION
This adds proper UTF-8 support for messages history and its clearing mechanism. 

Prior to this, the number of trailing spaces used to clear the 'pushed' messages in the history was not taking into account that a single character could be on more than one byte (e.g `ㅁ` is `U+3141` and is represented by three bytes) and it was causing issue with 'partial' line clearing.

Here is an example with the aforementioned character:
![example](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/11390282/b758811e-a807-477d-97f8-869dd6bd9873)
