### PR TITLE
Previous Rank -> Previous Act Rank

### DIFF
--- a/src/questions.py
+++ b/src/questions.py
@@ -6,7 +6,7 @@ TABLE_OPTS = {
     "rr": "Ranked Rating",
     "leaderboard": "Leaderboard Position",
     "peakrank": "Peak Rank",
-    "previousrank": "Previous Rank",
+    "previousrank": "Previous Act Rank",
     "headshot_percent": "Headshot Percentage",
     "winrate": "WinRate",
     "kd": "K/D Ratio <!> Last Game Only <!>",

--- a/src/table.py
+++ b/src/table.py
@@ -12,7 +12,7 @@ TABLE_COLUMN_NAMES = Literal[
     "Rank",
     "RR",
     "Peak Rank",
-    "Previous Rank",
+    "Previous Act Rank",
     "Pos.",
     "HS",
     "WR",


### PR DESCRIPTION
`Previous Act Rank`  is what it should have been named, instead of `Previous Rank`, which could be understood as 'rank before the current game'