### PR TITLE
Adds Outlaw support (E8:A1 new weapon)

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -146,6 +146,7 @@ WEAPONS = [
     "Phantom",
     "Vandal",
     "Marshal",
+    "Outlaw",
     "Operator",
     "Ares",
     "Odin",


### PR DESCRIPTION
Adds support for the [newly introduced weapon, Outlaw, in Episode 8: Act I](https://playvalorant.com/en-us/news/game-updates/a-new-addition-to-the-arsenal-outlaw-insights/) when running the configurator using `--config` flag:

```bash
python main.py --config
```

![--config after](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/48498042/598cf640-7396-4ce6-bbed-7337d1198ed9)

![config.json after](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/48498042/27e758b1-2407-4aa7-82f6-bbfdcdafab10)

Now it correctly sets the `Outlaw` weapon value in config.json instead of setting it to `null`. As a result, the app no longer defaults to showing the skin for the `Vandal`.

https://github.com/zayKenyon/VALORANT-rank-yoinker/blob/70d7ef0161f0bace1e59f3f908932777a36925cc/src/questions.py#L26-L32

![--config before](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/48498042/b8f608f4-e9be-4a8b-a6a3-84347f8ae9a3)

![config.json before](https://github.com/zayKenyon/VALORANT-rank-yoinker/assets/48498042/f56535e6-06b1-4b20-a38a-91c312eaa4fd)



