### PR TITLE
Small syntax error in exception message

### DIFF
--- a/main.py
+++ b/main.py
@@ -811,9 +811,9 @@ except:
     log(traceback.format_exc())
     print(color(
         "The program has encountered an error. If the problem persists, please reach support"
-        f" with the logs found in {os.getcwd()}\logs", fore=(255, 0, 0)))
+        f" with the logs found in {os.getcwd()}\\logs", fore=(255, 0, 0)))
     chatlog(color(
         "The program has encountered an error. If the problem persists, please reach support"
-        f" with the logs found in {os.getcwd()}\logs", fore=(255, 0, 0)))
+        f" with the logs found in {os.getcwd()}\\logs", fore=(255, 0, 0)))
     input("press enter to exit...\n")
     os._exit(1)


### PR DESCRIPTION
Fixes Issue #178 

In Lines 814 and 817 of main.py:

"\l" is an escape sequence in python,
"\\\l" would print \logs as intended