### PR TITLE
Fix for OS detection failing on some ocasions and stopping the software

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,13 +67,9 @@ try:
     Logging = Logging()
     log = Logging.log
 
-    # OS Logging + quit if OS unsupported
-    if get_os()[1] == False:
-        print(f"Unsupported operating system: {get_os()[0]}\n")
-        log(f"Unsupported operating system: {get_os()[0]}\n")
-        program_exit(0)
-    else:
-        log(f"Operating system: {get_os()[0]}\n")
+    # OS Logging
+    log(f"Operating system: {get_os()}\n")
+    
     try:
         if len(sys.argv) > 1 and sys.argv[1] == "--config":
             configure()

--- a/src/os.py
+++ b/src/os.py
@@ -3,21 +3,9 @@ import platform
 # This function detects the OS the user is running and if Valorant is officially supported in said platform
 # returns ["operating system" (string), "Runs Valorant" (bool)]
 def get_os():   
-    system = platform.system()
-
-    if system == "Windows":
-        # Detects if Windows version **is not** 10 or 11
-        if platform.win32_ver()[0] != str(10 or 11):
+    # Handles Windows operating systems
+    if platform.system() == "Windows":
             return f"Windows {platform.win32_ver()[0]} {platform.win32_edition()} {platform.win32_ver()[1]}"
-        
-        # Workaround for Windows 11 being detected as Windows 10, might not be necessary in the future
-        # https://github.com/python/cpython/issues/89545
-        if int(platform.win32_ver()[1].split(".")[-1]) >= 22000:
-            return f"Windows 11 {platform.win32_edition()} {platform.win32_ver()[1]}"
-        else:
-            return f"Windows 10 {platform.win32_edition()} {platform.win32_ver()[1]}"
-        
-
-    # Handles other Operating systems, such as Linux or Mac OS
+    # Handles other operating systems, such as Linux or Mac OS
     else:
         return "Non-Windows operating system"

--- a/src/os.py
+++ b/src/os.py
@@ -4,20 +4,20 @@ import platform
 # returns ["operating system" (string), "Runs Valorant" (bool)]
 def get_os():   
     system = platform.system()
-    
+
     if system == "Windows":
         # Detects if Windows version **is not** 10 or 11
         if platform.win32_ver()[0] != str(10 or 11):
-            return f"Windows {platform.win32_ver()[0]} {platform.win32_edition()} {platform.win32_ver()[1]}", False
+            return f"Windows {platform.win32_ver()[0]} {platform.win32_edition()} {platform.win32_ver()[1]}"
         
         # Workaround for Windows 11 being detected as Windows 10, might not be necessary in the future
         # https://github.com/python/cpython/issues/89545
         if int(platform.win32_ver()[1].split(".")[-1]) >= 22000:
-            return f"Windows 11 {platform.win32_edition()} {platform.win32_ver()[1]}", True
+            return f"Windows 11 {platform.win32_edition()} {platform.win32_ver()[1]}"
         else:
-            return f"Windows 10 {platform.win32_edition()} {platform.win32_ver()[1]}", True
+            return f"Windows 10 {platform.win32_edition()} {platform.win32_ver()[1]}"
         
 
     # Handles other Operating systems, such as Linux or Mac OS
     else:
-        return "Non-Windows operating system", False
+        return "Non-Windows operating system"


### PR DESCRIPTION
Fixes [this discord ticket](https://discord.com/channels/872101595037446144/1193467658251804682/1193467658251804682) by removing code that stops the software for unsupported systems and removing the workaround for Windows 11 detection.