### PR TITLE
Add an installer script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'installer-script'
     
   pull_request:
     types: [review_requested]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'installer-script'
     
   pull_request:
     types: [review_requested]

--- a/install.bat
+++ b/install.bat
@@ -1,5 +1,7 @@
 @echo off
 
+@REM Admin privileges are needed because without them, the installer won't be able to place a shortcut to vRY in the Start Menu folder, therefore not allowing you to access vRY as easily.
+@REM By "Start menu folder", I'm referring to C:\ProgramData\Microsoft\Windows\Start Menu\Programs
 if not "%1"=="am_admin" (powershell start -verb runas '%0' am_admin & exit /b)
 
 cd %~dp0

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,9 @@
+@echo off
+
+if not "%1"=="am_admin" (powershell start -verb runas '%0' am_admin & exit /b)
+
+cd %~dp0
+
+vry.exe --install
+
+PAUSE

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from src.configurator import configure
 from src.constants import *
 from src.content import Content
 from src.errors import Error
+from src.installer import install
 from src.Loadouts import Loadouts
 from src.logs import Logging
 from src.names import Names
@@ -84,10 +85,19 @@ try:
                 os.system('cls')
             else:
                 os._exit(0)
+        elif len(sys.argv) > 1 and sys.argv[1] == "--install":
+            install()
+            run_app = inquirer.confirm(
+                message="Do you want to run vRY now?", default=True
+            ).execute() 
+            if run_app:
+                os.system('cls')
+            else:
+                os._exit(0)
         else:
             os.system('cls')
     except Exception as e:
-        print("Something went wrong while running configurator!")
+        print("Something went wrong while running configurator or installer!")
         log(f"configurator encountered an error")
         log(str(traceback.format_exc()))
         input("press enter to exit...\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pfzy==0.3.4
 prompt-toolkit==3.0.39
 Pygments==2.15.1
 pypresence==4.3.0
+pywin32==306
 PyYAML==6.0.1
 requests==2.31.0
 rich==13.5.1

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ from src.constants import version
 
 build_exe_options = {
     "path": sys.path,
-    "include_files":['configurator.bat', 'updatescript.bat'],
+    "include_files":['configurator.bat', 'updatescript.bat', 'install.bat'],
     "packages": ["requests", "colr", "InquirerPy", "websockets", "pypresence", "nest_asyncio", "rich", "websocket_server"],
-    "excludes": ["tkinter", "test", "unittest", "pygments", "xmlrpc"]
+    "excludes": ["test", "unittest", "pygments", "xmlrpc"]
 }
 
 setup(

--- a/src/installer.py
+++ b/src/installer.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import shutil
+import pythoncom
+import tkinter
+from tkinter import filedialog
+from win32com.shell import shell
+
+def install():
+    # This prevents an empty tkinter window from appearing
+    tkinter.Tk().withdraw()
+
+    print("Select a directory to install vRY to.")
+
+    current_directory = os.getcwd() # Gets the directory from which vRY's exectuable is being run.
+    vry_install_path = filedialog.askdirectory(title="Select to a directory to install vRY to") # The directory in which the user chose vRY to be installed in.
+
+    print("Copying files to install directory. Please wait...")
+
+    # Copies all of vRY's files to the user's chosen install directory.
+    shutil.copytree(current_directory, vry_install_path, dirs_exist_ok=True)
+
+    print("Creating start menu shortcut...")
+
+    create_start_menu_shortcut(vry_install_path + "/vry.exe", vry_install_path)
+
+    print("Installation complete!")
+
+def create_start_menu_shortcut(vry_exe_path, working_dir):
+    shortcut_dir = r"C:\ProgramData\Microsoft\Windows\Start Menu\Programs"
+    shortcut_path = shortcut_dir + r"\VALORANT Rank Yoinker.lnk"
+
+    vry_shortcut = pythoncom.CoCreateInstance(shell.CLSID_ShellLink, None, pythoncom.CLSCTX_INPROC_SERVER, shell.IID_IShellLink)
+    persistent_file = vry_shortcut.QueryInterface(pythoncom.IID_IPersistFile)
+
+    vry_shortcut.SetPath(vry_exe_path)
+    vry_shortcut.SetWorkingDirectory(working_dir)
+    persistent_file.Save(shortcut_path, 0)
+


### PR DESCRIPTION
Added a script which copies all of the vry's files into a directory of the user's choosing, and then creates a start menu shortcut so that vry can be easily accessed.

This introduces PyWin32 and Tkinter as dependencies. PyWin32 for access to the Win32 API and Tkinter for the ability to open file dialog windows.