### PR TITLE
Update upload-artifact version to allow Github actions to run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
   
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
Fixes the 'This request has been automatically failed because it uses a deprecated version' error that is shown when Github actions automatically tries to build after a commit.