### PR TITLE
Changed the checked process

### DIFF
--- a/START.bat
+++ b/START.bat
@@ -1,4 +1,5 @@
 @echo off
-cd /d "%~dp0"    #  Change directory to batch script path.
+:: Change directory to batch script path
+cd /d "%~dp0"
 python "main.py"
 pause

--- a/src/account_manager/account_manager.py
+++ b/src/account_manager/account_manager.py
@@ -195,10 +195,10 @@ class AccountManager:
     def _is_valorant_running(self):
         try:
             output = subprocess.check_output(
-                ["tasklist", "/FI", "IMAGENAME eq VALORANT.exe"],
+                ["tasklist", "/FI", "IMAGENAME eq VALORANT-Win64-Shipping.exe"],
                 creationflags=subprocess.CREATE_NO_WINDOW
             ).decode().lower()
-            return "valorant.exe" in output
+            return "VALORANT-Win64-Shipping.exe" in output
         except:
             return False
 


### PR DESCRIPTION
On Windows 11, `valorant.exe` might get closed for some mysterious reason by riot (?).
The most accurate thing to do then is to check the `VALORANT-Win64-Shipping.exe` process.

This is a necessary fix and doesn't negatively affect anything.
However, it doesn't completely solve all the problems happening on Windows 11; these are still being investigated (as was discussed on Discord).