### PR TITLE
Fix GAMEPODS crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,8 +42,6 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 os.system(f"title VALORANT rank yoinker v{version}")
 
-server = ""
-
 
 def program_exit(status: int):  # so we don't need to import the entire sys module
     log(f"exited program with error code {status}")
@@ -268,10 +266,6 @@ try:
                     )
                 Wss.set_player_data(players_data)
 
-                try:
-                    server = GAMEPODS[coregame_stats["GamePodID"]]
-                except KeyError:
-                    server = "New server"
                 presences.wait_for_presence(namesClass.get_players_puuid(Players))
                 names = namesClass.get_names_from_puuids(Players)
                 loadouts_arr = loadoutsClass.get_match_loadouts(
@@ -591,10 +585,6 @@ try:
                 pregame_stats = pregame.get_pregame_stats()
                 if pregame_stats == None:
                     continue
-                try:
-                    server = GAMEPODS[pregame_stats["GamePodID"]]
-                except KeyError:
-                    server = "New server"
                 Players = pregame_stats["AllyTeam"]["Players"]
                 presences.wait_for_presence(namesClass.get_players_puuid(Players))
                 names = namesClass.get_names_from_puuids(Players)
@@ -963,13 +953,7 @@ try:
             if (title := game_state_dict.get(game_state)) is None:
                 # program_exit(1)
                 time.sleep(9)
-            if server != "":
-                table.set_title(
-                    f"VALORANT status: {title} {colr('- ' + server, fore=(200, 200, 200))}"
-                )
-            else:
-                table.set_title(f"VALORANT status: {title}")
-            server = ""
+            table.set_title(f"VALORANT status: {title}")
             if title is not None:
                 if cfg.get_feature_flag("auto_hide_leaderboard") and (
                     not is_leaderboard_needed

--- a/src/constants.py
+++ b/src/constants.py
@@ -81,9 +81,6 @@ AGENTCOLORLIST = {
     "tejo": (255, 183, 97),
 }
 
-
-GAMEPODS = requests.get("https://valorant-api.com/internal/locres/en-US").json()["data"]["UI_GamePodStrings"]
-
 symbol = "■"
 PARTYICONLIST = [
             color(symbol, fore=(227, 67, 67)),


### PR DESCRIPTION
Valorant-api has removed its internal endpoints and no longer returns GAMEPODS.
It was used to visually display the region name; it is not important.

It is possible without using gamepods by detecting the region internally (NA, BR, etc.) and listing the correct name for each region in constants.py

I did not do this because we needed a quick fix for the crash, and because on July 29th, Valorant will be migrating to UE5, so we may need to rewrite more code.