### PR TITLE
Fix for 11.02 Patch

### DIFF
--- a/src/content.py
+++ b/src/content.py
@@ -12,7 +12,7 @@ class Content():
 
     def get_latest_season_id(self, content):
         for season in content["Seasons"]:
-            if season["IsActive"]:
+            if season["IsActive"] and season["Type"] == "act":
                 self.log(f"retrieved season id: {season['ID']}")
                 return season["ID"]
 


### PR DESCRIPTION
Riot Games changed something in the season content api endpoint, and now there is an active type episode and act:
Example:
{
	"ID": "c470d964-4bf4-1261-87aa-c484252f2d66",
	"Name": "V25",
	"Type": "episode",
	"StartTime": "2025-06-26T03:15:00Z",
	"EndTime": "2026-01-08T03:15:00Z",
	"IsActive": true
},
{
	"ID": "ac12e9b3-47e6-9599-8fa1-0bb473e5efc7",
	"Name": "ACT IV",
	"Type": "act",
	"StartTime": "2025-06-26T03:15:00Z",
	"EndTime": "2025-08-21T03:15:00Z",
	"IsActive": true
}