### PR TITLE
Add optional starting side display (Attacker/Defender) in pregame lobby

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 os.system(f"title VALORANT rank yoinker v{version}")
 
 server = ""
+team_side = None
 
 
 def program_exit(status: int):  # so we don't need to import the entire sys module
@@ -964,18 +965,22 @@ try:
             if (title := game_state_dict.get(game_state)) is None:
                 # program_exit(1)
                 time.sleep(9)
+            
+            title_parts = [f"VALORANT status: {title}"]
+            
+            if game_state == "PREGAME" and pregame_stats is not None and not hide_starting_side:
+                team_side = "Attacker" if pregame_stats["AllyTeam"]["TeamID"] == "Red" else "Defender"
+                title_parts.append(f" | {colr(team_side, fore=(76, 151, 237) if team_side == 'Defender' else (238, 77, 77))}")
+            
             if cfg.get_feature_flag("server_id") and server != "":
                 parts = server.split('.')
                 if len(parts) > 2:
                     short_serverID = '.'.join(parts[2:])
                 else:
                     short_serverID = server
-
-                table.set_title(
-                    f"VALORANT status: {title} {colr('- ' + short_serverID, fore=(200, 200, 200))}"
-                )
-            else:
-                table.set_title(f"VALORANT status: {title}")
+                title_parts.append(f" {colr('- ' + short_serverID, fore=(200, 200, 200))}")
+            
+            table.set_title(''.join(title_parts))
             
             if title is not None:
                 if cfg.get_feature_flag("auto_hide_leaderboard") and (

--- a/main.py
+++ b/main.py
@@ -968,7 +968,7 @@ try:
             
             title_parts = [f"VALORANT status: {title}"]
             
-            if game_state == "PREGAME" and pregame_stats is not None and not hide_starting_side:
+            if game_state == "PREGAME" and pregame_stats is not None and cfg.get_feature_flag("starting_side"):
                 team_side = "Attacker" if pregame_stats["AllyTeam"]["TeamID"] == "Red" else "Defender"
                 title_parts.append(f" | {colr(team_side, fore=(76, 151, 237) if team_side == 'Defender' else (238, 77, 77))}")
             

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,6 +5,7 @@ version = "2.90"
 enablePrivateLogging = True
 hide_names = True
 hide_levels = True
+hide_starting_side = True
 
 
 gamemodes = {

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,7 +5,6 @@ version = "2.90"
 enablePrivateLogging = True
 hide_names = True
 hide_levels = True
-hide_starting_side = True
 
 
 gamemodes = {
@@ -216,6 +215,7 @@ DEFAULT_CONFIG = {
             "server_id": False,
             "short_ranks": False,
             "truncate_skins": True,
-            "truncate_names": True
+            "truncate_names": True,
+            "starting_side": False
         }
     }

--- a/src/questions.py
+++ b/src/questions.py
@@ -25,7 +25,8 @@ FLAGS_OPTS = {
     "server_id": "Show Server Region ID",
     "short_ranks": "Short rank names instead of long ones",
     "truncate_skins": "Truncate long skin names if the window is too small",
-    "truncate_names": "Truncate long player names if the window is too small"
+    "truncate_names": "Truncate long player names if the window is too small",
+    "starting_side": "Display starting side (Attacker/Defender) while in the pregame lobby"
 }
 
 weapon_question = lambda config: {


### PR DESCRIPTION
This feature adds an optional display in the pregame lobby showing the player's starting side (Attacker vs Defender) in color (red/blue) in the terminal.